### PR TITLE
Ipywidgets dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,12 @@
   },
   "jupyterlab": {
     "extension": true,
+    "sharedPackages": {
+      "@jupyter-widgets/base": {
+        "bundled": false,
+        "singleton": true
+      }
+    }
     "outputDir": "yjs_widgets/labextension"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "bundled": false,
         "singleton": true
       }
-    }
+    },
     "outputDir": "yjs_widgets/labextension"
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   },
   "jupyterlab": {
     "extension": true,
-    "outputDir": "yjs_widgets/labextension",
-    "webpackConfig": "./extension.webpack.config.js"
+    "outputDir": "yjs_widgets/labextension"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ name = "yjs-widgets"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
-dependencies = []
+dependencies = [
+    "jupyterlab_widgets>=3"
+]
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",


### PR DESCRIPTION
This PR adds a missing dependency on `jupyterlab_widgets`

<img src=https://github.com/user-attachments/assets/4eaf256b-051c-4465-af95-837974c93d5a width=500>

cc. @martinRenou who suggested the change.